### PR TITLE
Wrong documentation on how to call the decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ PidFile can also be used a a decorator::
 
   from pid.decorator import pidfile
   
-  @pidfile
+  @pidfile()
   def main():
     pass
 


### PR DESCRIPTION
The documentation should include the parentheses for the decorator.
