### PR TITLE
Default to lazy setup (and an additional check).

### DIFF
--- a/pid/__init__.py
+++ b/pid/__init__.py
@@ -31,18 +31,16 @@ class PidFileAlreadyLockedError(PidFileError):
 
 class PidFile(object):
     __slots__ = ("pid", "pidname", "piddir", "enforce_dotpid_postfix", "register_term_signal_handler",
-                 "term_signal_handler", "filename", "fh", "lock_pidfile", "chmod", "uid",
+                 "filename", "fh", "lock_pidfile", "chmod", "uid",
                  "gid", "force_tmpdir", "lazy", "_logger")
 
     def __init__(self, pidname=None, piddir=None, enforce_dotpid_postfix=True,
-                 register_term_signal_handler=True, term_signal_handler=None,
-                 lock_pidfile=True, chmod=0o644, uid=-1, gid=-1, force_tmpdir=False,
-                 lazy=True):
+                 register_term_signal_handler=True, lock_pidfile=True, chmod=0o644,
+                 uid=-1, gid=-1, force_tmpdir=False, lazy=True):
         self.pidname = pidname
         self.piddir = piddir
         self.enforce_dotpid_postfix = enforce_dotpid_postfix
         self.register_term_signal_handler = register_term_signal_handler
-        self.term_signal_handler = term_signal_handler
         self.lock_pidfile = lock_pidfile
         self.chmod = chmod
         self.uid = uid
@@ -58,7 +56,6 @@ class PidFile(object):
 
         if not self.lazy:
             self._setup()
-
 
     @property
     def logger(self):
@@ -104,14 +101,11 @@ class PidFile(object):
         if self.register_term_signal_handler:
             # Register TERM signal handler to make sure atexit runs on TERM signal
 
-            term_signal_handler = self.term_signal_handler
-            if term_signal_handler is None:
-                def sigterm_noop_handler(*args, **kwargs):
-                    raise SystemExit(1)
-                term_signal_handler = sigterm_noop_handler
+            def sigterm_noop_handler(*args, **kwargs):
+                raise SystemExit(1)
+            term_signal_handler = sigterm_noop_handler
 
-            if signal.getsignal(signal.SIGTERM) is not term_signal_handler:
-                signal.signal(signal.SIGTERM, term_signal_handler)
+            signal.signal(signal.SIGTERM, term_signal_handler)
 
     def check(self):
 

--- a/pid/__init__.py
+++ b/pid/__init__.py
@@ -103,9 +103,8 @@ class PidFile(object):
 
             def sigterm_noop_handler(*args, **kwargs):
                 raise SystemExit(1)
-            term_signal_handler = sigterm_noop_handler
 
-            signal.signal(signal.SIGTERM, term_signal_handler)
+            signal.signal(signal.SIGTERM, sigterm_noop_handler)
 
     def check(self):
 

--- a/pid/__init__.py
+++ b/pid/__init__.py
@@ -37,7 +37,7 @@ class PidFile(object):
     def __init__(self, pidname=None, piddir=None, enforce_dotpid_postfix=True,
                  register_term_signal_handler=True, term_signal_handler=None,
                  lock_pidfile=True, chmod=0o644, uid=-1, gid=-1, force_tmpdir=False,
-                 lazy=False):
+                 lazy=True):
         self.pidname = pidname
         self.piddir = piddir
         self.enforce_dotpid_postfix = enforce_dotpid_postfix

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,11 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[pep8]
+# ignore line too long (>79 char) warnings 
+ignore = E501
+
+[flake8]
+# ignore line too long (>79 char) warnings 
+ignore = E501

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -103,9 +103,10 @@ def test_pid_custom_term_signal():
     def _custom_signal_func(*args, **kwargs):
         pass
 
-    signal.signal(signal.SIGTERM, _noop)
-    with pid.PidFile(register_term_signal_handler=True, term_signal_handler=_custom_signal_func):
-        assert signal.getsignal(signal.SIGTERM) is _custom_signal_func
+    signal.signal(signal.SIGTERM, _custom_signal_func)
+    assert signal.getsignal(signal.SIGTERM) is _custom_signal_func
+    with pid.PidFile(register_term_signal_handler=True):
+        assert signal.getsignal(signal.SIGTERM) is not _custom_signal_func
 
 
 def test_pid_chmod():

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -202,6 +202,15 @@ def test_pid_lazy_check_already_running():
             pidfile2.check()
 
 
+def test_pid_double_lazy_check_already_running():
+    with pid.PidFile(lazy=True):
+        # context manager should be entered at this
+        # point and the PID locked
+        pidfile2 = pid.PidFile(lazy=True)
+        with raising(pid.PidFileAlreadyRunningError):
+            pidfile2.check()
+
+
 def test_pid_lazy_check_is_none():
     pidfile = pid.PidFile(lazy=True)
     assert pidfile.check() is None


### PR DESCRIPTION
In relation to https://github.com/trbs/pid/issues/4.

The following PR is a culmination of fixing the following issue:

```
with pid.PidFile(lazy=True):
    # (1) pid is locked at this point
    pidfile2 = pid.PidFile(lazy=True)
    with raising(pid.PidFileAlreadyRunningError):
        # (2) the pidfile2._setup() isn't called when performing check()
        pidfile2.check()
```

I made a test and the appropriate fix to support double lazy checks. I then tried the testsuite defaulting `lazy=True` and that also worked. Furthermore, I moved the `logging` to the `_setup()` phase, because we cannot make assumptions whether the internal logging stream handle would be available after daemonization. It isn't elegant but I beleive it is the correct approach when combining `pid` with a daemon manager.