### PR TITLE
Include documentation files in the sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-include DESCRIPTION.rst
+include AUTHORS
+include CHANGELOG
+include LICENSE


### PR DESCRIPTION
In particular I'm interested in getting LICENSE into the sdist tarball, since that would make things easier for anyone redistributing the code to satisfy the

```
(a) You must give any other recipients of the Work or
          Derivative Works a copy of this License;
```

condition.