### PR TITLE
Fix packaging issues, to improve situation downstream

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-include AUTHORS
-include CHANGELOG
-include LICENSE
+include README.rst LICENSE AUTHORS CHANGELOG
+graft pid
+graft tests
+global-exclude *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(
     packages=["pid"],
     install_requires=[],
     test_suite='nose.collector',
-    setup_requires=['nose>=1.0'],
+    tests_require=['nose>=1.0'],
 )


### PR DESCRIPTION
These are improvements that will help when building downstream packages. Specifically, I am maintaining the FreeBSD port: https://www.freshports.org/devel/py-pid

- Add tests directory to MANIFEST.in, so that tests can be run when building the port.
- Put `nose` requirement in `tests_require` rather than `setup_requires`, to avoid confusion. The `setup_requires` category is only for custom setup scripts, not for test dependencies. (See https://setuptools.readthedocs.io/en/latest/setuptools.html for reference).

Hope this makes sense! =)