### PR TITLE
Use standard library mock when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
   - sudo chmod 0777 /var/run
 
 install:
-  - pip install "coverage>=3.6" "nose>=1.3.0" "flake8>=2.1" "coveralls>=0.3" "mock>=2.0.0"
+  - pip install "coverage>=3.6" "nose>=1.3.0" "flake8>=2.1" "coveralls>=0.3"
+  - dpkg --compare-versions $TRAVIS_PYTHON_VERSION ge 3.3 || pip install "mock>=2.0.0"
   - pip install -e .
 
 script:

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -2,7 +2,10 @@ import os
 import os.path
 import signal
 from contextlib import contextmanager
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 import pid
 


### PR DESCRIPTION
Mock was added to the standard library in Python 3.3, so there is no need to pip install it.