### PR TITLE
Added test that spawns a new python interpreter (for issue #25)

### DIFF
--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -9,6 +9,12 @@ try:
 except ImportError:
     from mock import patch
 
+try:
+    from subprocess import run
+except ImportError:
+    # python2 support
+    from subprocess import call as run
+
 import pid
 
 pid.DEFAULT_PID_DIR = "/tmp"
@@ -160,6 +166,16 @@ def test_pid_already_locked_custom_name():
         assert os.path.exists(_pid.filename)
     assert not os.path.exists(_pid.filename)
 
+def test_pid_already_locked_multi_process():
+    with pid.PidFile() as _pid:
+        s = '''
+import pid
+with pid.PidFile("pytest", piddir="/tmp"):
+    pass
+'''
+        run(['python', '-c', s])
+        assert os.path.exists(_pid.filename)
+    assert not os.path.exists(_pid.filename)
 
 def test_pid_already_running():
     with pid.PidFile(lock_pidfile=False) as _pid:


### PR DESCRIPTION
I'm not sure if there is a better way to test this. It needs to run in a separate interpreter for the atexit handler to run. I tried the test with version 2.2.0 and there it passes.