### PR TITLE
Do not hardcode "python" and "pytest" in tests

### DIFF
--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -174,7 +174,7 @@ import pid
 with pid.PidFile(os.path.basename(sys.argv[0]), piddir="/tmp"):
     pass
 '''
-        result = run(['python', '-c', s])
+        result = run([sys.executable, '-c', s])
         returncode = result if isinstance(result, int) else result.returncode
         assert returncode == 1
         assert os.path.exists(_pid.filename)
@@ -189,7 +189,7 @@ with pid.PidFile("pytest2", piddir="/tmp") as _pid:
     assert os.path.exists(_pid.filename)
 assert not os.path.exists(_pid.filename)
 '''
-        result = run(['python', '-c', s])
+        result = run([sys.executable, '-c', s])
         returncode = result if isinstance(result, int) else result.returncode
         assert returncode == 0
         assert os.path.exists(_pid.filename)

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -171,7 +171,7 @@ def test_pid_already_locked_multi_process():
     with pid.PidFile() as _pid:
         s = '''
 import pid
-with pid.PidFile("pytest", piddir="/tmp"):
+with pid.PidFile(os.path.basename(sys.argv[0]), piddir="/tmp"):
     pass
 '''
         result = run(['python', '-c', s])


### PR DESCRIPTION
I discovered these issues when packaging pid for Debian. Debian packaging tools run tests during the package build using `python3 -m pytest tests` which makes the tests fail because the default pidfile name is `pytest.py.pid` (because "executable" in this case is "pytest.py).
Also hardcoding "python" as executable name doesn't work on systems without Python 2 (`/usr/bin/python` is usually "reserved" for Python 2 so there is no `python` without Python 2).