### PR TITLE
Use APPDATA and HOME locations on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog
 3.0.4
 -----
 
- - Use APPDATA and HOME locations son Windows
+ - Use APPDATA and HOME locations on Windows
 
 
 3.0.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.0.4
+-----
+
+ - Use APPDATA and HOME locations son Windows
+
+
 3.0.3
 -----
 

--- a/pid/__init__.py
+++ b/pid/__init__.py
@@ -17,8 +17,7 @@ if sys.platform == "win32":
 else:
     from .posix import PidFile  # NOQA
 
-
-__version__ = "3.0.3"
+__version__ = "3.0.4"
 __all__ = [
     '__version__',
     'DEFAULT_PID_DIR',

--- a/pid/utils.py
+++ b/pid/utils.py
@@ -15,16 +15,19 @@ def effective_access(*args, **kwargs):
 
 def determine_pid_directory():
     if sys.platform == "win32":
-        return tempfile.gettempdir()
+        if 'APPDATA' in os.environ:
+            paths = [os.environ['APPDATA']]
+        else:
+            paths = [os.path.expanduser('~\\AppData\\Roaming')]
+    else:
+        uid = os.geteuid() if hasattr(os, "geteuid") else os.getuid()  # pylint: disable=no-member
 
-    uid = os.geteuid() if hasattr(os, "geteuid") else os.getuid()
-
-    paths = [
-        "/run/user/%s/" % uid,
-        "/var/run/user/%s/" % uid,
-        "/run/",
-        "/var/run/",
-    ]
+        paths = [
+            "/run/user/%s/" % uid,
+            "/var/run/user/%s/" % uid,
+            "/run/",
+            "/var/run/",
+        ]
 
     for path in paths:
         if effective_access(os.path.realpath(path), os.W_OK | os.X_OK):


### PR DESCRIPTION
Added logic to store the pidfile in APPDATA or ~\AppData\Roaming before defaulting to tempfile.gettempdir() on Windows, consistent with the POSIX implementation.