### PR TITLE
pytest-related updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,10 @@ setup(
     install_requires=[
         'psutil>=5.4.8 ; sys_platform == "win32"',
     ],
-    test_suite='nose.collector',
-    tests_require=['nose>=1.0'],
+    extras_require={
+        'tests': [
+            'mock ; python_version < "3"',
+            'pytest',
+        ]
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py36,py37,py38,py39,pypy,pypy3
+
+[testenv]
+extras =
+    tests
+commands =
+    pytest {posargs}


### PR DESCRIPTION
See individual commits for details. They can be cherry-picked separately if you prefer.

- use `pytest.raises()` instead of custom `raising()`
- replace `tests_require` with `extras_require` as expected by modern setuptools
- replace obsolete nose dep with pytest+mock
- add `tox.ini` to ease testing by users